### PR TITLE
Fix sorting handler

### DIFF
--- a/app/scripts/components/timeline_step.jsx
+++ b/app/scripts/components/timeline_step.jsx
@@ -21,7 +21,10 @@ define(function (require) {
                 var dateA = new Date(a.created_at);
                 var dateB = new Date(b.created_at);
 
-                return direction === 'asc' ? dateA > dateB : dateA < dateB;
+                if (direction === 'asc') {
+                    return dateA - dateB;
+                }
+                return dateB - dateA;
             };
 
             this.props.onSort(


### PR DESCRIPTION
The `compare(a, b)` function passed to `Array#sort` expects `0` if both elements are equal, less than `0` if `a` should come first, and greater than `0` if `b` should come first.

Previously, values less than `0` were never returned, causing the sorting to be wonky.
